### PR TITLE
fix pyvsag undefined symbol error

### DIFF
--- a/python_bindings/binding.cpp
+++ b/python_bindings/binding.cpp
@@ -1,3 +1,4 @@
+
 // Copyright 2024-present the vsag project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,20 +26,6 @@
 #include "vsag/vsag.h"
 
 namespace py = pybind11;
-
-py::array_t<float>
-kmeans(py::array_t<float, py::array::c_style | py::array::forcecast>& datas,
-       int clusters,
-       const std::string& dis_type) {
-    auto data_shape = datas.shape();
-    py::ssize_t py_clusters(clusters);
-    auto data_size = data_shape[0];
-    auto dimension = data_shape[1];
-    auto centroids = py::array_t<float>(py::array::ShapeContainer{py_clusters, dimension});
-    vsag::kmeans_clustering(
-        dimension, data_size, clusters, datas.data(), centroids.mutable_data(), dis_type);
-    return centroids;
-}
 
 class Index {
 public:
@@ -184,7 +171,6 @@ private:
 };
 
 PYBIND11_MODULE(pyvsag, m) {
-    m.def("kmeans", &kmeans, "Kmeans");
     py::class_<Index>(m, "Index")
         .def(py::init<std::string, std::string&>(), py::arg("name"), py::arg("parameters"))
         .def("build",


### PR DESCRIPTION
fix undefined symbol error in `import pyvsag`:
```python
>>> import pyvsag
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: /home/ubuntu/vsag/build/pyvsag.cpython-312-aarch64-linux-gnu.so: undefined symbol: _ZN4vsag17kmeans_clusteringEmmmPKfPfRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
```