### PR TITLE
make openblas always run with single thread

### DIFF
--- a/extern/openblas/openblas.cmake
+++ b/extern/openblas/openblas.cmake
@@ -21,7 +21,7 @@ ExternalProject_Add(
         OMP_NUM_THREADS=1
         PATH=/usr/lib/ccache:$ENV{PATH}
         LD_LIBRARY_PATH=/opt/alibaba-cloud-compiler/lib64/:$ENV{LD_LIBRARY_PATH}
-        make USE_OPENMP=1 -j${NUM_BUILDING_JOBS}
+        make USE_THREAD=0 USE_LOCKING=1 -j${NUM_BUILDING_JOBS}
     INSTALL_COMMAND
         make PREFIX=${install_dir} install
     BUILD_IN_SOURCE 1


### PR DESCRIPTION
diskann index building is a multi-thread task, so we should set openblas use single thread to avoid conflict.

https://github.com/OpenMathLib/OpenBLAS/wiki/Faq#how-can-i-use-openblas-in-multi-threaded-applications